### PR TITLE
Add Search to Docs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -68,6 +68,7 @@ theme:
 
 plugins:
   - mkdocstrings
+  - search
 
 markdown_extensions:
   - admonition


### PR DESCRIPTION
Looks like fixing #34 is as easy as adding the `search` plugin to `mkdocs` based on [this documentation](https://www.mkdocs.org/user-guide/configuration/#plugins).

Fixes #34 