### PR TITLE
Create `autodistill` CLI

### DIFF
--- a/autodistill/classification/__init__.py
+++ b/autodistill/classification/__init__.py
@@ -1,4 +1,4 @@
-from autodistill.classification.classification_base_model import ClassificationBaseModel
-from autodistill.classification.classification_target_model import (
-    ClassificationTargetModel,
-)
+from autodistill.classification.classification_base_model import \
+    ClassificationBaseModel
+from autodistill.classification.classification_target_model import \
+    ClassificationTargetModel

--- a/autodistill/cli.py
+++ b/autodistill/cli.py
@@ -1,0 +1,36 @@
+from autodistill.detection import CaptionOntology
+from autodistill.registry import import_requisite_module
+import os
+import click
+
+@click.command()
+@click.argument('dir')
+@click.option('--base', default='base', required=True)
+@click.option('--target', default='target', required=True)
+@click.option('--ontology', default={}, required=True)
+@click.option("--epochs", default=200, required=True)
+@click.option("--output", default="./dataset", required=True)
+def main(dir, base, target, ontology, epochs, output):
+    print("Loading base model...")
+    model = import_requisite_module(base)
+    ontology = CaptionOntology(ontology)
+    base_model = model(ontology=ontology)
+
+    print("Labeling data...")
+
+    base_model.label(
+        input_folder=dir,
+        output_folder=output
+    )
+
+    print("Loading target model...")
+    target_model = import_requisite_module(target)
+
+    print("Training target model...")
+    target_model.train(os.path.join(output, "data.yaml"), epochs=epochs)
+
+    print("✨ Your model has been trained! ✨")
+    
+    
+if __name__ == '__main__':
+    main()

--- a/autodistill/cli.py
+++ b/autodistill/cli.py
@@ -13,6 +13,8 @@ SUPPORTED_ROBOFLOW_MODEL_UPLOADS = ["yolov5", "yolov5-seg", "yolov8", "yolov8-se
 
 SUPPORTED_MODEL_TYPES = ["detection", "segmentation" "classification"]
 
+SUPPORTED_DATASET_FORMATS = ["yolov8", "yolov5", "voc"]
+
 
 @click.command()
 @click.argument("images")
@@ -22,11 +24,19 @@ SUPPORTED_MODEL_TYPES = ["detection", "segmentation" "classification"]
 @click.option("--ontology", default={}, required=True)
 @click.option("--epochs", default=200, required=True)
 @click.option("--output", default="./dataset", required=True)
-@click.option("--upload-to-roboflow", default="", required=False)
+@click.option("--upload-to-roboflow", default=False, required=False)
 @click.option("--project_license", default="MIT", required=False)
+@click.option("--dataset_format", default="voc", required=False)
 def main(
-    images, base, target, model_type, ontology, epochs, output, upload_to_roboflow, project_license
+    images, base, target, model_type, ontology, epochs, output, upload_to_roboflow, project_license, dataset_format
 ):
+    if dataset_format not in SUPPORTED_DATASET_FORMATS:
+        print(
+            "Dataset format not supported. Please choose from the following dataset formats: "
+            + str(SUPPORTED_DATASET_FORMATS)
+        )
+        exit()
+
     if model_type not in SUPPORTED_MODEL_TYPES:
         print(
             "Model type not supported. Please choose from the following model types: "
@@ -130,7 +140,7 @@ def main(
         rf.workspace().upload_dataset(
             dataset_path=output,
             project_name=project.id.split("/")[-1],
-            dataset_format="yolov8",
+            dataset_format=dataset_format,
             project_license=project_license,
             project_type=rf_model_value
         )

--- a/autodistill/cli.py
+++ b/autodistill/cli.py
@@ -1,22 +1,88 @@
-from autodistill.detection import CaptionOntology
-from autodistill.registry import import_requisite_module
+import json
 import os
+
 import click
+import cv2
+import roboflow
+import supervision as sv
+
+from autodistill.detection.caption_ontology import CaptionOntology
+from autodistill.registry import import_requisite_module
+
+SUPPORTED_ROBOFLOW_MODEL_UPLOADS = ["yolov5", "yolov5-seg", "yolov8", "yolov8-seg"]
+
+SUPPORTED_MODEL_TYPES = ["detection", "segmentation" "classification"]
+
 
 @click.command()
-@click.argument('dir')
-@click.option('--base', default='base', required=True)
-@click.option('--target', default='target', required=True)
-@click.option('--ontology', default={}, required=True)
+@click.argument("images")
+@click.option("--base", default="grounding_dino")
+@click.option("--target", default="yolov8")
+@click.option("--model_type", default="detection")
+@click.option("--ontology", default={}, required=True)
 @click.option("--epochs", default=200, required=True)
 @click.option("--output", default="./dataset", required=True)
-def main(dir, base, target, ontology, epochs, output):
+@click.option("--upload-to-roboflow", default=False, required=False)
+@click.option("--project_license", default="MIT", required=False)
+def main(
+    images, base, target, model_type, ontology, epochs, output, upload_to_roboflow, project_license
+):
+    if model_type not in SUPPORTED_MODEL_TYPES:
+        print(
+            "Model type not supported. Please choose from the following model types: "
+            + str(SUPPORTED_MODEL_TYPES)
+        )
+        exit()
+
+    if ontology == "{}":
+        print("No ontology provided. Please provide an ontology.")
+        exit()
+
     print("Loading base model...")
     model = import_requisite_module(base)
+
+    try:
+        ontology = json.loads(ontology, strict=False)
+    except:
+        print("Ontologies must be valid JSON.")
+        exit()
+
     ontology = CaptionOntology(ontology)
+
     base_model = model(ontology=ontology)
 
     print("Labeling data...")
+
+    # if dir is file, run label on file
+    if os.path.isfile(images):
+        classes = ontology.classes()
+
+        box_annotator = sv.BoxAnnotator()
+
+        image = cv2.imread(images)
+
+        base_model.label(
+            input_folder=os.path.dirname(images),
+            extension=os.path.splitext(images)[1],
+            output_folder=output,
+        )
+        # show results
+        detections = base_model.predict(images)
+
+        labels = [
+            f"{classes[class_id]} {confidence:0.2f}"
+            for _, _, confidence, class_id, _ in detections
+        ]
+
+        annotated_frame = box_annotator.annotate(
+            scene=image.copy(),
+            detections=detections,
+            labels=labels,
+        )
+
+        sv.plot_image(annotated_frame, size=(8, 8))
+
+        exit()
 
     base_model.label(
         input_folder=dir,
@@ -27,10 +93,60 @@ def main(dir, base, target, ontology, epochs, output):
     target_model = import_requisite_module(target)
 
     print("Training target model...")
-    target_model.train(os.path.join(output, "data.yaml"), epochs=epochs)
+    target_model.train(dataset_yaml=os.path.join(output, "data.yaml"), epochs=epochs)
+
+    if upload_to_roboflow:
+        roboflow.login()
+
+        rf = roboflow.Roboflow()
+
+        workspace = rf.workspace()
+
+        if model_type == "detection":
+            rf_model_value = "object-detection"
+        elif model_type == "segmentation":
+            rf_model_value = "image-segmentation"
+        else:
+            rf_model_value = "single-label-classification"
+
+        project = workspace.create_project(
+            "autodistill",
+            project_license=project_license,
+            annotation=ontology.classes()[0],
+            project_type=rf_model_value
+        )
+
+        rf.workspace().upload_dataset(
+            dataset_path=output,
+            project_name=project.id.split("/")[-1],
+            dataset_format="yolov8",
+            project_license=project_license,
+            project_type=rf_model_value
+        )
+
+        if model_type == "detection":
+            model_value = target
+        elif model_type == "segmentation":
+            model_value = target + "-seg"
+        else:
+            model_value = target + "-cls"
+
+        if model_value not in SUPPORTED_ROBOFLOW_MODEL_UPLOADS:
+            print(
+                f"Model type {model_value} is not supported by Roboflow. Please choose one of {SUPPORTED_ROBOFLOW_MODEL_UPLOADS}."
+            )
+            exit()
+
+        project.generate_version(settings={"augmentation": {}, "preprocessing": {}})
+
+        version = project.versions()[-1].version.split("/")[-1]
+
+        project.version(version).deploy(
+            model_type=model_value, model_path=f"./runs/detect/train/"
+        )
 
     print("✨ Your model has been trained! ✨")
-    
-    
-if __name__ == '__main__':
+
+
+if __name__ == "__main__":
     main()

--- a/autodistill/core/__init__.py
+++ b/autodistill/core/__init__.py
@@ -1,3 +1,3 @@
-from autodistill.core.base_model import BaseModel
-from autodistill.core.ontology import Ontology
-from autodistill.core.target_model import TargetModel
+from .base_model import BaseModel
+from .ontology import Ontology
+from .target_model import TargetModel

--- a/autodistill/core/base_model.py
+++ b/autodistill/core/base_model.py
@@ -4,7 +4,7 @@ from typing import Any
 
 import supervision as sv
 
-from autodistill.core import Ontology
+from .ontology import Ontology
 
 
 @dataclass

--- a/autodistill/detection/caption_ontology.py
+++ b/autodistill/detection/caption_ontology.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from typing import Dict, List, Tuple
 
-from autodistill.detection import DetectionOntology
+from autodistill.detection.detection_ontology import DetectionOntology
 
 
 @dataclass

--- a/autodistill/detection/detection_base_model.py
+++ b/autodistill/detection/detection_base_model.py
@@ -8,8 +8,9 @@ import supervision as sv
 from tqdm import tqdm
 
 from autodistill.core import BaseModel
-from autodistill.detection import DetectionOntology
 from autodistill.helpers import split_data
+
+from .detection_ontology import DetectionOntology
 
 
 @dataclass

--- a/autodistill/registry.py
+++ b/autodistill/registry.py
@@ -2,35 +2,39 @@ import importlib
 import os
 
 AUTODISTILL_MODULES = [
-    "groundedsam",
-    "yolov8",
-    "yolov5"
+    ("grounded_sam", "GroundedSAM"),
+    ("grounding_dino", "GroundingDINO"),
+    ("yolov8", "YOLOv8", "yolov8n.pt"),
+    ("yolov5", "YOLOv5", "yolov5n.pt"),
 ]
+
+PACKAGE_NAMES = [i[0] for i in AUTODISTILL_MODULES]
+
 
 def is_module_installed(module_name):
     try:
-        importlib.import_module(module_name)
-    except ImportError:
+        importlib.import_module("autodistill_" + module_name)
+    except:
         return False
-    else:
-        return True
+
+    return True
+
 
 def import_requisite_module(module_name):
-    if module_name not in AUTODISTILL_MODULES:
-        raise ValueError(f"Module {module_name} not found.")
-    
-    if not is_module_installed("autodistill_" + module_name):
-        os.system("pip install autodistill_" + module_name)
+    if module_name not in PACKAGE_NAMES:
+        print(
+            f"Module {module_name} not found. Please choose from the following modules: {PACKAGE_NAMES}"
+        )
+        exit()
 
-    if module_name == "groundedsam":
-        from autodistill_grounded_sam import GroundedSAM
+    if not is_module_installed(module_name):
+        os.system(f"pip install autodistill_{module_name}")
 
-        return GroundedSAM
-    elif module_name == "yolov8":
-        from autodistill_yolov8 import YOLOv8
+    module = importlib.import_module("autodistill_" + module_name)
 
-        return YOLOv8
-    elif module_name == "yolov5":
-        from autodistill_yolov5 import YOLOv5
+    full_module = AUTODISTILL_MODULES[PACKAGE_NAMES.index(module_name)]
 
-        return YOLOv5
+    if len(full_module) == 3:
+        return getattr(module, full_module[1])(full_module[2])
+
+    return getattr(module, full_module[1])

--- a/autodistill/registry.py
+++ b/autodistill/registry.py
@@ -1,0 +1,36 @@
+import importlib
+import os
+
+AUTODISTILL_MODULES = [
+    "groundedsam",
+    "yolov8",
+    "yolov5"
+]
+
+def is_module_installed(module_name):
+    try:
+        importlib.import_module(module_name)
+    except ImportError:
+        return False
+    else:
+        return True
+
+def import_requisite_module(module_name):
+    if module_name not in AUTODISTILL_MODULES:
+        raise ValueError(f"Module {module_name} not found.")
+    
+    if not is_module_installed("autodistill_" + module_name):
+        os.system("pip install autodistill_" + module_name)
+
+    if module_name == "groundedsam":
+        from autodistill_grounded_sam import GroundedSAM
+
+        return GroundedSAM
+    elif module_name == "yolov8":
+        from autodistill_yolov8 import YOLOv8
+
+        return YOLOv8
+    elif module_name == "yolov5":
+        from autodistill_yolov5 import YOLOv5
+
+        return YOLOv5

--- a/autodistill/registry.py
+++ b/autodistill/registry.py
@@ -39,7 +39,14 @@ def import_requisite_module(module_name):
         exit()
 
     if not is_module_installed(module_name):
-        os.system(f"pip install autodistill_{module_name}")
+        consent = input(
+            f"Module {module_name} is not installed. Would you like to install it? (y/n): "
+        )
+        if consent == "y":
+            os.system(f"pip install autodistill_{module_name}")
+        else:
+            print(f"{module_name} is required to run this script with your current configuration. Change your chosen model or run `autodistill` again to install {module_name}.")
+            exit()
 
     module = importlib.import_module("autodistill_" + module_name)
 

--- a/autodistill/registry.py
+++ b/autodistill/registry.py
@@ -6,6 +6,17 @@ AUTODISTILL_MODULES = [
     ("grounding_dino", "GroundingDINO"),
     ("yolov8", "YOLOv8", "yolov8n.pt"),
     ("yolov5", "YOLOv5", "yolov5n.pt"),
+    ("fastsam", "FastSAM"),
+    ("owl-vit", "OWLViT"),
+    ("albef", "ALBEF"),
+    ("detic", "DETIC"),
+    ("blipv2", "BLIPv2"),
+    ("sam-clip", "SAMCLIP"),
+    ("dinov2", "DINOv2"),
+    ("yolonas", "YOLONAS"),
+    ("blip", "BLIP"),
+    ("vit", "ViT"),
+    ("detr", "DETR"),
 ]
 
 PACKAGE_NAMES = [i[0] for i in AUTODISTILL_MODULES]

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ supervision
 tqdm
 Pillow>=7.1.2
 PyYAML>=5.3.1
+click

--- a/setup.py
+++ b/setup.py
@@ -1,20 +1,21 @@
-import setuptools
-from setuptools import find_packages
 import re
 
-with open("./autodistill/__init__.py", 'r') as f:
+import setuptools
+from setuptools import find_packages
+
+with open("./autodistill/__init__.py", "r") as f:
     content = f.read()
     # from https://www.py4u.net/discuss/139845
     version = re.search(r'__version__\s*=\s*[\'"]([^\'"]*)[\'"]', content).group(1)
-    
+
 with open("README.md", "r") as fh:
     long_description = fh.read()
 
 with open("requirements.txt", "r") as fh:
-    install_requires = fh.read().split('\n')
+    install_requires = fh.read().split("\n")
 
 setuptools.setup(
-    name="autodistill",  
+    name="autodistill",
     version=version,
     author="Roboflow",
     author_email="autodistill@roboflow.com",
@@ -30,7 +31,16 @@ setuptools.setup(
         ],
     },
     extras_require={
-        "dev": ["flake8", "black==22.3.0", "isort", "twine", "pytest", "wheel", "mkdocs-material", "mkdocs"],
+        "dev": [
+            "flake8",
+            "black==22.3.0",
+            "isort",
+            "twine",
+            "pytest",
+            "wheel",
+            "mkdocs-material",
+            "mkdocs",
+        ],
     },
     classifiers=[
         "Programming Language :: Python :: 3",

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,11 @@ setuptools.setup(
     url="https://github.com/autodistill/autodistill",
     install_requires=install_requires,
     packages=find_packages(exclude=("tests",)),
+    entry_points={
+        "console_scripts": [
+            "autodistill=autodistill.cli:main",
+        ],
+    },
     extras_require={
         "dev": ["flake8", "black==22.3.0", "isort", "twine", "pytest", "wheel", "mkdocs-material", "mkdocs"],
     },


### PR DESCRIPTION
This PR creates an `autodistill` command line interface. This interface is installed with the package. Using the command line interface, developers can use autodistill in a single command, without having to manually install the requisite packages and write scripts to use each module.