### PR TITLE
Add function to split frames into video

### DIFF
--- a/autodistill/helpers.py
+++ b/autodistill/helpers.py
@@ -90,22 +90,6 @@ def split_data(base_dir, split_ratio=0.8):
         }
         yaml.dump(data, file)
 
-
-def visualize_predictions(file_name: str, detections: sv.Detections) -> None:
-    if detections.mask is None:
-        annotator = sv.BoxAnnotator()
-    else:
-        annotator = sv.MaskAnnotator()
-
-    image = cv2.imread(file_name)
-
-    image_bgr = cv2.cvtColor(image, cv2.COLOR_RGB2BGR)
-
-    annotated_image = annotator.annotate(scene=image_bgr, detections=detections)
-
-    sv.plot_image(annotated_image)
-
-
 def split_video_frames(video_path: str, output_dir: str, stride: int) -> None:
     video_paths = sv.list_files_with_extensions(
         directory=video_path, extensions=["mov", "mp4", "MOV", "MP4"]

--- a/autodistill/helpers.py
+++ b/autodistill/helpers.py
@@ -90,6 +90,7 @@ def split_data(base_dir, split_ratio=0.8):
         }
         yaml.dump(data, file)
 
+
 def split_video_frames(video_path: str, output_dir: str, stride: int) -> None:
     video_paths = sv.list_files_with_extensions(
         directory=video_path, extensions=["mov", "mp4", "MOV", "MP4"]

--- a/autodistill/helpers.py
+++ b/autodistill/helpers.py
@@ -91,9 +91,7 @@ def split_data(base_dir, split_ratio=0.8):
         yaml.dump(data, file)
 
 
-def visualize_predictions(
-    file_name: str, detections: sv.Detections
-) -> None:
+def visualize_predictions(file_name: str, detections: sv.Detections) -> None:
     if detections.mask is None:
         annotator = sv.BoxAnnotator()
     else:

--- a/autodistill/helpers.py
+++ b/autodistill/helpers.py
@@ -2,8 +2,13 @@ import os
 import random
 import shutil
 
+import cv2
+import supervision as sv
+import tqdm
 import yaml
 from PIL import Image
+
+VALID_ANNOTATION_TYPES = ["box", "mask"]
 
 
 def split_data(base_dir, split_ratio=0.8):
@@ -84,3 +89,36 @@ def split_data(base_dir, split_ratio=0.8):
             "names": names,
         }
         yaml.dump(data, file)
+
+
+def visualize_predictions(
+    file_name: str, detections: sv.Detections
+) -> None:
+    if detections.mask is None:
+        annotator = sv.BoxAnnotator()
+    else:
+        annotator = sv.MaskAnnotator()
+
+    image = cv2.imread(file_name)
+
+    image_bgr = cv2.cvtColor(image, cv2.COLOR_RGB2BGR)
+
+    annotated_image = annotator.annotate(scene=image_bgr, detections=detections)
+
+    sv.plot_image(annotated_image)
+
+
+def split_video_frames(video_path: str, output_dir: str, stride: int) -> None:
+    video_paths = sv.list_files_with_extensions(
+        directory=video_path, extensions=["mov", "mp4", "MOV", "MP4"]
+    )
+
+    for name in tqdm(video_paths):
+        image_name_pattern = name + "-{:05d}.jpg"
+        with sv.ImageSink(
+            target_dir_path=output_dir, image_name_pattern=image_name_pattern
+        ) as sink:
+            for image in sv.get_video_frames_generator(
+                source_path=str(video_path), stride=stride
+            ):
+                sink.save_image(image=image)


### PR DESCRIPTION
I have created a new split_video_frames function that, given a path, will go through all videos, split them up into frames, and save those frames in the desired output directory. This function makes it easier to work with videos as an input.

This is an updated version of #12, in which both Roboflow upload code and the video helper code was bundled. This PR includes changes based on all video-related notes in the PR.