### PR TITLE
Add Kapa bot to Autodistill docs

### DIFF
--- a/docs/javascript/init_kapa_widget.js
+++ b/docs/javascript/init_kapa_widget.js
@@ -1,0 +1,10 @@
+document.addEventListener("DOMContentLoaded", function () {
+    var script = document.createElement("script");
+    script.src = "https://widget.kapa.ai/kapa-widget.bundle.js";
+    script.setAttribute("data-website-id", "e83c5c60-2968-410b-a2da-08fb104f23df");
+    script.setAttribute("data-project-name", "Roboflow");
+    script.setAttribute("data-project-color", "#6405C9");
+    script.setAttribute("data-project-logo", "https:/media.roboflow.com/chat.png");
+    script.async = true;
+    document.head.appendChild(script);
+});  

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -86,3 +86,7 @@ markdown_extensions:
       alternate_style: true
   - toc:
       permalink: true
+
+extra_javascript:
+  - "https://widget.kapa.ai/kapa-widget.bundle.js"
+  - "javascript/init_kapa_widget.js"


### PR DESCRIPTION
# Description

This PR adds the Kapa AI-powered documentation bot to the `autodistill` documentation.

## Type of change

-  Documentation change

## How has this change been tested, please provide a testcase or example of how you tested the change?

This change was tested by running `mkdocs serve`, opening `localhost:8000`, and checking that the "Ask AI" bot in the bottom right corner has the correct image.

## Any specific deployment considerations

N/A

## Docs

N/A