### PR TITLE
Fix documentation

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -8,8 +8,7 @@
     </a>
   </p>
 </div>
-  
-</div>
+
 
 [notebooks](https://github.com/roboflow/notebooks) | [inference](https://github.com/roboflow/inference) | [autodistill](https://github.com/autodistill/autodistill) | [collect](https://github.com/roboflow/roboflow-collect)
 


### PR DESCRIPTION
This PR fixes the `docs.autodistill.com` site, which is not rendering properly due to an errant div.