### PR TITLE
Update README read() encoding

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("./autodistill/__init__.py", "r") as f:
     # from https://www.py4u.net/discuss/139845
     version = re.search(r'__version__\s*=\s*[\'"]([^\'"]*)[\'"]', content).group(1)
 
-with open("README.md", "r") as fh:
+with open("README.md", "r", encoding="UTF-8") as fh:
     long_description = fh.read()
 
 setuptools.setup(


### PR DESCRIPTION
This PR updates the encoding used to open `README.md` in our `setup.py` file, which should resolve #32.