### PR TITLE
Fix Roboflow Universe link

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ tasks first but plan to launch classification support soon! In the future, we ho
 | [LLaVA-1.5](https://github.com/autodistill/autodistill-llava) | ✅ | ✅ | ✅ | ✅ | 🚧 |  |  |
 | [Kosmos-2](https://github.com/autodistill/autodistill-kosmos-2) | ✅ | ✅ | ✅ | ✅ | 🚧 |  |  |
 | [OWLv2](https://github.com/autodistill/autodistill-owlv2) | ✅ | ✅ | ✅ | ✅ | 🚧 |  |  |
-| [Roboflow Universe Models (50](https://github.com/000+ pre-trained models)) | ✅ | ✅ | ✅ | ✅ | 🚧 |  |  |
+| [Roboflow Universe Models (50k+ pre-trained models)](https://github.com/autodistill/autodistill-roboflow-universe) | ✅ | ✅ | ✅ | ✅ | 🚧 |  |  |
 | [Azure Custom Vision](https://github.com/autodistill/autodistill-azure-vision) | ✅ | ✅ | ✅ | ✅ | 🚧 |  |  |
 | [AWS Rekognition](https://github.com/autodistill/autodistill-rekognition) | ✅ | ✅ | ✅ | ✅ | 🚧 |  |  |
 | [Google Vision](https://github.com/autodistill/autodistill-gcp-vision) | ✅ | ✅ | ✅ | ✅ | 🚧 |  |  |

--- a/automation/models.csv
+++ b/automation/models.csv
@@ -9,7 +9,7 @@ object-detection, 1, 0, completed, SAM-CLIP, autodistill/autodistill-sam-clip, a
 object-detection, 1, 0, completed, LLaVA-1.5, autodistill/autodistill-llava, autodistill-llava, base_models/llava.md, Apache-2.0
 object-detection, 1, 0, completed, Kosmos-2, autodistill/autodistill-kosmos-2, autodistill-kosmos-2, base_models/kosmos_2.md, Apache-2.0
 object-detection, 1, 0, completed, OWLv2, autodistill/autodistill-owlv2, autodistill-owlv2, base_models/owlv2.md, Apache-2.0
-object-detection, 1, 0, completed, Roboflow Universe Models (50,000+ pre-trained models), autodistill/autodistill-roboflow-universe, autodistill-roboflow-universe, base_models/roboflow_universe.md, MIT
+object-detection, 1, 0, completed, Roboflow Universe Models (50k+ pre-trained models), autodistill/autodistill-roboflow-universe, autodistill-roboflow-universe, base_models/roboflow_universe.md, MIT
 object-detection, 1, 0, completed, Azure Custom Vision, autodistill/autodistill-azure-vision, autodistill-azure-vision, base_models/azure_vision.md, MIT
 object-detection, 1, 0, completed, AWS Rekognition, autodistill/autodistill-rekognition, autodistill-rekognition, base_models/rekognition.md, Apache-2.0
 object-detection, 1, 0, completed, Google Vision, autodistill/autodistill-gcp-vision, autodistill-gcp-vision, base_models/gcp_vision.md, Apache-2.0

--- a/docs/index.md
+++ b/docs/index.md
@@ -244,7 +244,7 @@ tasks first but plan to launch classification support soon! In the future, we ho
 | [LLaVA-1.5](https://github.com/autodistill/autodistill-llava) | ✅ | ✅ | ✅ | ✅ | 🚧 |  |  |
 | [Kosmos-2](https://github.com/autodistill/autodistill-kosmos-2) | ✅ | ✅ | ✅ | ✅ | 🚧 |  |  |
 | [OWLv2](https://github.com/autodistill/autodistill-owlv2) | ✅ | ✅ | ✅ | ✅ | 🚧 |  |  |
-| [Roboflow Universe Models (50](https://github.com/000+ pre-trained models)) | ✅ | ✅ | ✅ | ✅ | 🚧 |  |  |
+| [Roboflow Universe Models (50k+ pre-trained models)](https://github.com/autodistill/autodistill-roboflow-universe) | ✅ | ✅ | ✅ | ✅ | 🚧 |  |  |
 | [Azure Custom Vision](https://github.com/autodistill/autodistill-azure-vision) | ✅ | ✅ | ✅ | ✅ | 🚧 |  |  |
 | [AWS Rekognition](https://github.com/autodistill/autodistill-rekognition) | ✅ | ✅ | ✅ | ✅ | 🚧 |  |  |
 | [Google Vision](https://github.com/autodistill/autodistill-gcp-vision) | ✅ | ✅ | ✅ | ✅ | 🚧 |  |  |


### PR DESCRIPTION
This PR fixes the broken link pointing to the `autodistill-roboflow-universe` module in the README and project documentation.