### PR TITLE
Add `FewShotOntology` for object detection

### DIFF
--- a/autodistill/detection/few_shot_ontology.py
+++ b/autodistill/detection/few_shot_ontology.py
@@ -1,0 +1,26 @@
+from dataclasses import dataclass
+from typing import List, Tuple
+import roboflow
+
+from autodistill.detection.detection_ontology import DetectionOntology
+
+
+@dataclass
+class FewShotOntology(DetectionOntology):
+    promptMap: List[Tuple[str, str]]
+
+    def __init__(self, roboflow_dataset_id: str, number_of_shots: int):
+        roboflow.login()
+
+        self.roboflow_dataset_id = roboflow_dataset_id
+        self.number_of_shots = number_of_shots
+        self.promptMap = []
+
+        if len(self.promptMap) == 0:
+            raise ValueError("Ontology is empty")
+
+    def prompts(self) -> List[str]:
+        return super().prompts()
+
+    def classToPrompt(self, cls: str) -> str:
+        return super().classToPrompt(cls)

--- a/autodistill/utils.py
+++ b/autodistill/utils.py
@@ -37,18 +37,23 @@ def compare(models: list, images: List[str]):
 def plot(image: np.ndarray, detections, classes: List[str], raw=False):
     # TODO: When we have a classification annotator
     # in supervision, we can add it here
-    if detections.mask:
-        annotator = sv.MaskAnnotator()
+    if detections.mask is not None:
+        annotator = sv.MaskAnnotator() #opacity=0.9)
     else:
         annotator = sv.BoxAnnotator()
 
+    label_annotator = sv.LabelAnnotator(text_position=sv.Position.CENTER)
+
     labels = [
-        f"{classes[class_id]} {confidence:0.2f}"
+        f"{classes[class_id]}"
         for _, _, confidence, class_id, _ in detections
     ]
 
     annotated_frame = annotator.annotate(
-        scene=image.copy(), detections=detections, labels=labels
+        scene=image.copy(), detections=detections
+    )
+    annotated_frame = label_annotator.annotate(
+        scene=annotated_frame, labels=labels, detections=detections
     )
 
     if raw:


### PR DESCRIPTION
This PR introduces the `FewShotOntology` ontology which can be used for few shot object detection.

This API will allow a user to pass in a Roboflow dataset ID and a number of images to retrieve. A similarity search will then happen on a dataset to retrieve images related to a prompt.

The tasks we want to complete are:

- [ ] Add support to the Roboflow API for dataset search
- [ ] Add support for the `FewShotOntology` into the GPT-4V module