### PR TITLE
Add Roboflow as a dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ tqdm
 Pillow>=7.1.2
 PyYAML>=5.3.1
 click
+roboflow


### PR DESCRIPTION
This PR adds `roboflow` to the `autodistill` `requirements.txt` file, fixing the bug where users would be asked to install `roboflow` when using Autodistill.