### PR TITLE
Prevent folder name conflicts in label() call

### DIFF
--- a/autodistill/classification/classification_base_model.py
+++ b/autodistill/classification/classification_base_model.py
@@ -2,6 +2,7 @@ import glob
 import os
 from abc import abstractmethod
 from dataclasses import dataclass
+import datetime
 
 import cv2
 import supervision as sv
@@ -25,6 +26,11 @@ class ClassificationBaseModel(BaseModel):
     ) -> sv.ClassificationDataset:
         if output_folder is None:
             output_folder = input_folder + "_labeled"
+
+        # check if output folder exists
+        if os.path.exists(output_folder):
+            # if it does, append timestamp to it
+            output_folder += "_" + datetime.datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
 
         os.makedirs(output_folder, exist_ok=True)
 
@@ -57,4 +63,4 @@ class ClassificationBaseModel(BaseModel):
         valid_cs.as_folder_structure(root_directory_path=output_folder + "/valid")
 
         print("Labeled dataset created - ready for distillation.")
-        return dataset
+        return dataset, output_folder

--- a/autodistill/detection/detection_base_model.py
+++ b/autodistill/detection/detection_base_model.py
@@ -35,6 +35,11 @@ class DetectionBaseModel(BaseModel):
         if output_folder is None:
             output_folder = input_folder + "_labeled"
 
+        # check if output folder exists
+        if os.path.exists(output_folder):
+            # if it does, append timestamp to it
+            output_folder += "_" + datetime.datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+
         os.makedirs(output_folder, exist_ok=True)
 
         images_map = {}
@@ -75,4 +80,4 @@ class DetectionBaseModel(BaseModel):
             workspace.upload_dataset(output_folder, project_name=roboflow_project)
 
         print("Labeled dataset created - ready for distillation.")
-        return dataset
+        return dataset, output_folder


### PR DESCRIPTION
This PR appends a timestamp of when `label()` was called to the output folder label name if the provided folder name already exists and contains images.

This PR prevents the scenario where `label()` labels a dataset (which could be hundreds or thousands of images) then returns an error after labeling because the existing folder already contains an image with the same name as one in the newly-labeled dataset.