### PR TITLE
Remove `annotator` argument from `ComposedDetectionModel.predict()`

### DIFF
--- a/autodistill/core/composed_detection_model.py
+++ b/autodistill/core/composed_detection_model.py
@@ -26,7 +26,7 @@ class ComposedDetectionModel(DetectionBaseModel):
         self.set_of_marks_annotator = set_of_marks_annotator
         self.ontology = self.classification_model.ontology
 
-    def predict(self, image: str, annotator) -> sv.Detections:
+    def predict(self, image: str) -> sv.Detections:
         """
         Run inference with a detection model then run inference with a classification model on the detected regions.
 


### PR DESCRIPTION
The `ComposedDetectionModel.predict()` function accepts a mandatory annotator argument, which causes the following error when you try to use `.label()` (which consumes `.predict()`):

```
TypeError: ComposedDetectionModel.predict() missing 1 required positional argument: 'annotator’
```

This PR fixes this issue.

In addition, we may want to think about integrations with Multimodal Maestro for Set of Mark. This is something we can introduce in separate PRs, however.