### PR TITLE
Fix #107

### DIFF
--- a/autodistill/detection/detection_base_model.py
+++ b/autodistill/detection/detection_base_model.py
@@ -65,7 +65,7 @@ class DetectionBaseModel(BaseModel):
             if sahi:
                 detections = slicer(image)
             else:
-                detections = self.predict(f_path)
+                detections = self.predict(image)
 
             detections_map[f_path_short] = detections
 

--- a/autodistill/detection/detection_base_model.py
+++ b/autodistill/detection/detection_base_model.py
@@ -63,7 +63,7 @@ class DetectionBaseModel(BaseModel):
             images_map[f_path_short] = image.copy()
 
             if sahi:
-                detections = slicer(f_path)
+                detections = slicer(image)
             else:
                 detections = self.predict(f_path)
 


### PR DESCRIPTION
This PR fixes #107, which notes that SAHI doesn't work when used with the `label()` method.

This bug was caused by passing in the file name associated with an image.

This PR also passes in the `cv2` image that is loaded with `label()` directly into a base model. This prevents the base model from having to open the image again, which is inefficient.

Here is a test case for this code:

```python
from autodistill_grounding_dino import GroundingDINO
from autodistill.detection import CaptionOntology

base_model = GroundingDINO(ontology=CaptionOntology({"person": "person"}))

base_model.label(
    input_folder="./images",
    output_folder="./dataset",
    sahi=True
)
```

There should be no error raised when `label()` labels an image.

Here is an example of an image labeled **without** SAHI:

<img width="1383" alt="Screenshot 2023-12-28 at 09 32 54" src="https://github.com/autodistill/autodistill/assets/37276661/98254ac7-e8ec-409e-b1d8-ad7f34a6f0eb">

Here is an example of an image labeled with SAHI:

<img width="1376" alt="Screenshot 2023-12-28 at 09 40 55" src="https://github.com/autodistill/autodistill/assets/37276661/1376d37f-a4ea-417d-918c-4618ec425faf">
