### PR TITLE
Added code to optionally save the confidence value

### DIFF
--- a/autodistill/detection/detection_base_model.py
+++ b/autodistill/detection/detection_base_model.py
@@ -3,15 +3,16 @@ import glob
 import os
 from abc import abstractmethod
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Dict
+
 import cv2
+import numpy as np
 import roboflow
 import supervision as sv
 from supervision.utils.file import save_text_file
-import numpy as np
 from tqdm import tqdm
 
-from pathlib import Path
 from autodistill.core import BaseModel
 from autodistill.helpers import load_image, split_data
 
@@ -31,22 +32,23 @@ class DetectionBaseModel(BaseModel):
 
         return slicer(load_image(input, return_format="cv2"))
 
-    def _record_confidence_in_files(self, 
-       annotations_directory_path: str,
-       images: Dict[str, np.ndarray],
-       annotations: Dict[str, sv.Detections]
+    def _record_confidence_in_files(
+        self,
+        annotations_directory_path: str,
+        images: Dict[str, np.ndarray],
+        annotations: Dict[str, sv.Detections],
     ) -> None:
         Path(annotations_directory_path).mkdir(parents=True, exist_ok=True)
         for image_name, _ in images.items():
             detections = annotations[image_name]
             yolo_annotations_name, _ = os.path.splitext(image_name)
             confidence_path = os.path.join(
-                annotations_directory_path, "confidence-"+yolo_annotations_name + ".txt"
+                annotations_directory_path,
+                "confidence-" + yolo_annotations_name + ".txt",
             )
             confidence_list = [str(x) for x in detections.confidence.tolist()]
             save_text_file(lines=confidence_list, file_path=confidence_path)
 
-    
     def label(
         self,
         input_folder: str,
@@ -56,7 +58,7 @@ class DetectionBaseModel(BaseModel):
         roboflow_project: str = None,
         roboflow_tags: str = ["autodistill"],
         sahi: bool = False,
-        record_confidence: bool = False
+        record_confidence: bool = False,
     ) -> sv.DetectionDataset:
         """
         Label a dataset with the model.
@@ -99,12 +101,11 @@ class DetectionBaseModel(BaseModel):
             min_image_area_percentage=0.01,
             data_yaml_path=output_folder + "/data.yaml",
         )
-        
+
         if record_confidence is True:
             self._record_confidence_in_files(
-                output_folder+ "/annotations",
-                images_map, 
-                detections_map)
+                output_folder + "/annotations", images_map, detections_map
+            )
         split_data(output_folder)
 
         if human_in_the_loop:

--- a/autodistill/detection/detection_base_model.py
+++ b/autodistill/detection/detection_base_model.py
@@ -48,6 +48,7 @@ class DetectionBaseModel(BaseModel):
             )
             confidence_list = [str(x) for x in detections.confidence.tolist()]
             save_text_file(lines=confidence_list, file_path=confidence_path)
+            print("Saved confidence file: " + confidence_path)
 
     def label(
         self,

--- a/autodistill/detection/detection_base_model.py
+++ b/autodistill/detection/detection_base_model.py
@@ -3,12 +3,15 @@ import glob
 import os
 from abc import abstractmethod
 from dataclasses import dataclass
-
+from typing import Dict
 import cv2
 import roboflow
 import supervision as sv
+from supervision.utils.file import save_text_file
+import numpy as np
 from tqdm import tqdm
 
+from pathlib import Path
 from autodistill.core import BaseModel
 from autodistill.helpers import load_image, split_data
 
@@ -28,6 +31,22 @@ class DetectionBaseModel(BaseModel):
 
         return slicer(load_image(input, return_format="cv2"))
 
+    def _record_confidence_in_files(self, 
+       annotations_directory_path: str,
+       images: Dict[str, np.ndarray],
+       annotations: Dict[str, sv.Detections]
+    ) -> None:
+        Path(annotations_directory_path).mkdir(parents=True, exist_ok=True)
+        for image_name, _ in images.items():
+            detections = annotations[image_name]
+            yolo_annotations_name, _ = os.path.splitext(image_name)
+            confidence_path = os.path.join(
+                annotations_directory_path, "confidence-"+yolo_annotations_name + ".txt"
+            )
+            confidence_list = [str(x) for x in detections.confidence.tolist()]
+            save_text_file(lines=confidence_list, file_path=confidence_path)
+
+    
     def label(
         self,
         input_folder: str,
@@ -37,6 +56,7 @@ class DetectionBaseModel(BaseModel):
         roboflow_project: str = None,
         roboflow_tags: str = ["autodistill"],
         sahi: bool = False,
+        record_confidence: bool = False
     ) -> sv.DetectionDataset:
         """
         Label a dataset with the model.
@@ -79,7 +99,12 @@ class DetectionBaseModel(BaseModel):
             min_image_area_percentage=0.01,
             data_yaml_path=output_folder + "/data.yaml",
         )
-
+        
+        if record_confidence is True:
+            self._record_confidence_in_files(
+                output_folder+ "/annotations",
+                images_map, 
+                detections_map)
         split_data(output_folder)
 
         if human_in_the_loop:

--- a/autodistill/helpers.py
+++ b/autodistill/helpers.py
@@ -129,29 +129,22 @@ def split_data(base_dir, split_ratio=0.8):
     os.makedirs(valid_labels_dir, exist_ok=True)
 
     # Move the files
+    def _check_move_file(source_dir, source_file, dest_dir):
+        if not os.path.exists(os.path.join(source_dir, source_file)):
+            print(f"Did not find {os.path.join(source_dir, source_file)}, not moving anything to {dest_dir}")
+        if os.path.exists(os.path.join(dest_dir, source_file)):
+            print(f"Found {os.path.join(dest_dir, source_file)} as already present, not moving anything to {dest_dir}")
+        shutil.move(os.path.join(source_dir, source_file), dest_dir)
+    
     for file in train_files:
-        shutil.move(os.path.join(images_dir, file + ".jpg"), train_images_dir)
-        shutil.move(os.path.join(annotations_dir, file + ".txt"), train_labels_dir)
-        confidence_file_path =  os.path.join(annotations_dir, "confidence-" + file + ".txt")
-        if os.path.exists(confidence_file_path):
-            shutil.move(
-                confidence_file_path,
-                train_labels_dir,
-             )
-        else:
-            print(f'Did not find {confidence_file_path}')
+        _check_move_file(images_dir, file + ".jpg", train_images_dir)
+        _check_move_file(annotations_dir, file + ".txt", train_labels_dir)
+        _check_move_file(annotations_dir, "confidence-" + file + ".txt", train_labels_dir)
 
     for file in valid_files:
-        shutil.move(os.path.join(images_dir, file + ".jpg"), valid_images_dir)
-        shutil.move(os.path.join(annotations_dir, file + ".txt"), valid_labels_dir)
-        confidence_file_path =  os.path.join(annotations_dir, "confidence-" + file + ".txt")
-        if os.path.exists(confidence_file_path):
-            shutil.move(
-                confidence_file_path,
-                train_labels_dir,
-             )
-        else:
-            print(f'Did not find {confidence_file_path}')
+        _check_move_file(images_dir, file + ".jpg", valid_images_dir)
+        _check_move_file(annotations_dir, file + ".txt", valid_labels_dir)
+        _check_move_file(annotations_dir, "confidence-" + file + ".txt", valid_labels_dir)
 
     # Load the existing YAML file to get the names
     with open(os.path.join(base_dir, "data.yaml"), "r") as file:

--- a/autodistill/helpers.py
+++ b/autodistill/helpers.py
@@ -132,10 +132,13 @@ def split_data(base_dir, split_ratio=0.8):
     for file in train_files:
         shutil.move(os.path.join(images_dir, file + ".jpg"), train_images_dir)
         shutil.move(os.path.join(annotations_dir, file + ".txt"), train_labels_dir)
+        shutil.move(os.path.join(annotations_dir, "confidence-" + file + ".txt"), train_labels_dir)
+
 
     for file in valid_files:
         shutil.move(os.path.join(images_dir, file + ".jpg"), valid_images_dir)
         shutil.move(os.path.join(annotations_dir, file + ".txt"), valid_labels_dir)
+        shutil.move(os.path.join(annotations_dir, "confidence-" + file + ".txt"), valid_labels_dir)
 
     # Load the existing YAML file to get the names
     with open(os.path.join(base_dir, "data.yaml"), "r") as file:

--- a/autodistill/helpers.py
+++ b/autodistill/helpers.py
@@ -131,20 +131,28 @@ def split_data(base_dir, split_ratio=0.8):
     # Move the files
     def _check_move_file(source_dir, source_file, dest_dir):
         if not os.path.exists(os.path.join(source_dir, source_file)):
-            print(f"Did not find {os.path.join(source_dir, source_file)}, not moving anything to {dest_dir}")
+            print(
+                f"Did not find {os.path.join(source_dir, source_file)}, not moving anything to {dest_dir}"
+            )
         if os.path.exists(os.path.join(dest_dir, source_file)):
-            print(f"Found {os.path.join(dest_dir, source_file)} as already present, not moving anything to {dest_dir}")
+            print(
+                f"Found {os.path.join(dest_dir, source_file)} as already present, not moving anything to {dest_dir}"
+            )
         shutil.move(os.path.join(source_dir, source_file), dest_dir)
-    
+
     for file in train_files:
         _check_move_file(images_dir, file + ".jpg", train_images_dir)
         _check_move_file(annotations_dir, file + ".txt", train_labels_dir)
-        _check_move_file(annotations_dir, "confidence-" + file + ".txt", train_labels_dir)
+        _check_move_file(
+            annotations_dir, "confidence-" + file + ".txt", train_labels_dir
+        )
 
     for file in valid_files:
         _check_move_file(images_dir, file + ".jpg", valid_images_dir)
         _check_move_file(annotations_dir, file + ".txt", valid_labels_dir)
-        _check_move_file(annotations_dir, "confidence-" + file + ".txt", valid_labels_dir)
+        _check_move_file(
+            annotations_dir, "confidence-" + file + ".txt", valid_labels_dir
+        )
 
     # Load the existing YAML file to get the names
     with open(os.path.join(base_dir, "data.yaml"), "r") as file:

--- a/autodistill/helpers.py
+++ b/autodistill/helpers.py
@@ -132,13 +132,18 @@ def split_data(base_dir, split_ratio=0.8):
     for file in train_files:
         shutil.move(os.path.join(images_dir, file + ".jpg"), train_images_dir)
         shutil.move(os.path.join(annotations_dir, file + ".txt"), train_labels_dir)
-        shutil.move(os.path.join(annotations_dir, "confidence-" + file + ".txt"), train_labels_dir)
-
+        shutil.move(
+            os.path.join(annotations_dir, "confidence-" + file + ".txt"),
+            train_labels_dir,
+        )
 
     for file in valid_files:
         shutil.move(os.path.join(images_dir, file + ".jpg"), valid_images_dir)
         shutil.move(os.path.join(annotations_dir, file + ".txt"), valid_labels_dir)
-        shutil.move(os.path.join(annotations_dir, "confidence-" + file + ".txt"), valid_labels_dir)
+        shutil.move(
+            os.path.join(annotations_dir, "confidence-" + file + ".txt"),
+            valid_labels_dir,
+        )
 
     # Load the existing YAML file to get the names
     with open(os.path.join(base_dir, "data.yaml"), "r") as file:

--- a/autodistill/helpers.py
+++ b/autodistill/helpers.py
@@ -132,18 +132,26 @@ def split_data(base_dir, split_ratio=0.8):
     for file in train_files:
         shutil.move(os.path.join(images_dir, file + ".jpg"), train_images_dir)
         shutil.move(os.path.join(annotations_dir, file + ".txt"), train_labels_dir)
-        shutil.move(
-            os.path.join(annotations_dir, "confidence-" + file + ".txt"),
-            train_labels_dir,
-        )
+        confidence_file_path =  os.path.join(annotations_dir, "confidence-" + file + ".txt")
+        if os.path.exists(confidence_file_path):
+            shutil.move(
+                confidence_file_path,
+                train_labels_dir,
+             )
+        else:
+            print(f'Did not find {confidence_file_path}')
 
     for file in valid_files:
         shutil.move(os.path.join(images_dir, file + ".jpg"), valid_images_dir)
         shutil.move(os.path.join(annotations_dir, file + ".txt"), valid_labels_dir)
-        shutil.move(
-            os.path.join(annotations_dir, "confidence-" + file + ".txt"),
-            valid_labels_dir,
-        )
+        confidence_file_path =  os.path.join(annotations_dir, "confidence-" + file + ".txt")
+        if os.path.exists(confidence_file_path):
+            shutil.move(
+                confidence_file_path,
+                train_labels_dir,
+             )
+        else:
+            print(f'Did not find {confidence_file_path}')
 
     # Load the existing YAML file to get the names
     with open(os.path.join(base_dir, "data.yaml"), "r") as file:


### PR DESCRIPTION
This PR allows a user to optionally set a parameter called "record_confidence" to True (default is false). 

The confidence returned by model for each predicted class is stored in a text file named `confidence-<image_name>.txt` in the annotations folder.