### PR TITLE
Add option to use with_nms in detection model label method

### DIFF
--- a/autodistill/detection/detection_base_model.py
+++ b/autodistill/detection/detection_base_model.py
@@ -60,6 +60,7 @@ class DetectionBaseModel(BaseModel):
         roboflow_tags: str = ["autodistill"],
         sahi: bool = False,
         record_confidence: bool = False,
+        with_nms: bool = False,
     ) -> sv.DetectionDataset:
         """
         Label a dataset with the model.
@@ -89,6 +90,9 @@ class DetectionBaseModel(BaseModel):
                 detections = slicer(f_path)
             else:
                 detections = self.predict(f_path)
+
+            if with_nms:
+                detections = detections.with_nms()
 
             detections_map[f_path_short] = detections
 


### PR DESCRIPTION
Adds an optional `with_nms` param to `label` method of `DetectionBaseModel`. Defaults to `False` to maintain existing behavior if param is unspecified.