### PR TITLE
Remove `scikit-learn` as dependency

### DIFF
--- a/autodistill/core/embedding_ontology.py
+++ b/autodistill/core/embedding_ontology.py
@@ -3,7 +3,6 @@ from typing import Any, Dict, List
 
 import numpy as np
 import supervision as sv
-from sklearn.metrics.pairwise import cosine_similarity
 
 from autodistill.core.embedding_model import EmbeddingModel
 from autodistill.core.ontology import Ontology

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ Pillow>=7.1.2
 PyYAML>=5.3.1
 roboflow
 pyyaml
+scikit-learn

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,3 @@ Pillow>=7.1.2
 PyYAML>=5.3.1
 roboflow
 pyyaml
-scikit-learn


### PR DESCRIPTION
This PR removes use of `scikit-learn` in `autodistill`.