### PR TITLE
add option to class agnostic NMS

### DIFF
--- a/autodistill/detection/detection_base_model.py
+++ b/autodistill/detection/detection_base_model.py
@@ -18,6 +18,14 @@ from autodistill.helpers import load_image, split_data
 
 from .detection_ontology import DetectionOntology
 
+import enum
+
+
+class NmsSetting(enum.Enum):
+    NONE = 'no_nms'
+    CLASS_SPECIFIC = 'class_specific'
+    CLASS_AGNOSTIC = 'class_agnostic'
+
 
 @dataclass
 class DetectionBaseModel(BaseModel):
@@ -60,7 +68,7 @@ class DetectionBaseModel(BaseModel):
         roboflow_tags: str = ["autodistill"],
         sahi: bool = False,
         record_confidence: bool = False,
-        with_nms: bool = False,
+        nms_settings: NmsSetting = NmsSetting.NONE,
     ) -> sv.DetectionDataset:
         """
         Label a dataset with the model.
@@ -91,8 +99,10 @@ class DetectionBaseModel(BaseModel):
             else:
                 detections = self.predict(image)
 
-            if with_nms:
+            if nms_settings == NmsSetting.CLASS_SPECIFIC:
                 detections = detections.with_nms()
+            if nms_settings == NmsSetting.CLASS_AGNOSTIC:
+                detections = detections.with_nms(class_agnostic=True)
 
             detections_map[f_path_short] = detections
 


### PR DESCRIPTION
Instead of passing a bool for use_nms, this changes the parameter from `use_nms` to `nms_settings` which accepts an enum to determine whether to use nms and if so whether to do it with class_agnostic=True