### PR TITLE
Updates prediction function argument hints

### DIFF
--- a/autodistill/detection/detection_base_model.py
+++ b/autodistill/detection/detection_base_model.py
@@ -11,6 +11,7 @@ import cv2
 import numpy as np
 import roboflow
 import supervision as sv
+from PIL import Image
 from supervision.utils.file import save_text_file
 from tqdm import tqdm
 
@@ -31,10 +32,10 @@ class DetectionBaseModel(BaseModel):
     ontology: DetectionOntology
 
     @abstractmethod
-    def predict(self, input: str) -> sv.Detections:
+    def predict(self, input: str | np.ndarray | Image.Image) -> sv.Detections:
         pass
 
-    def sahi_predict(self, input: str) -> sv.Detections:
+    def sahi_predict(self, input: str | np.ndarray | Image.Image) -> sv.Detections:
         slicer = sv.InferenceSlicer(callback=self.predict)
 
         return slicer(load_image(input, return_format="cv2"))


### PR DESCRIPTION
The sole `str` type is incorrect as Autodistill base modules can accept inputs as PIL image, a NumPy array or a string with a file path. This can lead to implementation misunderstandings and mistakes in IDE autocompletes.