### PR TITLE
Update to support newer versions of Supervision

### DIFF
--- a/autodistill/utils.py
+++ b/autodistill/utils.py
@@ -62,7 +62,7 @@ def plot(image: np.ndarray, detections, classes: List[str], raw=False):
     if detections.mask is not None:
         annotator = sv.MaskAnnotator()
     else:
-        annotator = sv.BoxAnnotator()
+        annotator = sv.BoundingBoxAnnotator()
 
     label_annotator = sv.LabelAnnotator()
 

--- a/autodistill/utils.py
+++ b/autodistill/utils.py
@@ -68,7 +68,7 @@ def plot(image: np.ndarray, detections, classes: List[str], raw=False):
 
     labels = [
         f"{classes[class_id]} {confidence:0.2f}"
-        for _, _, confidence, class_id, _ in detections
+        for _, _, confidence, class_id, _, _ in detections
     ]
 
     annotated_frame = annotator.annotate(scene=image.copy(), detections=detections)


### PR DESCRIPTION
Newer versions of Supervision have two changes that cause issues with the current implementation:
- the previous `BoxAnnotator` is deprecated, replaced by `BoundingBoxAnnotator`
- an additional value (`tracker_id`) was added to the Detections API iteration

The changes in this PR resolve these incompatibilities. Tested in a Colab on the branch