### PR TITLE
Dynamic temporary jpeg creation for ComposedDetectionModel

### DIFF
--- a/autodistill/core/composed_detection_model.py
+++ b/autodistill/core/composed_detection_model.py
@@ -1,3 +1,4 @@
+import tempfile
 import numpy as np
 import supervision as sv
 from PIL import Image
@@ -53,16 +54,18 @@ class ComposedDetectionModel(DetectionBaseModel):
 
             opened_image = Image.fromarray(annotated_frame)
 
-            opened_image.save("temp.jpeg")
+            # save as tempfile
+            with tempfile.NamedTemporaryFile(suffix=".jpeg", dir=".", prefix="detection_") as cropped_detection_file:
+                opened_image.save(cropped_detection_file.name)
 
-            if not hasattr(self.classification_model, "set_of_marks"):
-                raise Exception(
-                    f"The set classification model does not have a set_of_marks method. Supported models: {SET_OF_MARKS_SUPPORTED_MODELS}"
+                if not hasattr(self.classification_model, "set_of_marks"):
+                    raise Exception(
+                        f"The set classification model does not have a set_of_marks method. Supported models: {SET_OF_MARKS_SUPPORTED_MODELS}"
+                    )
+
+                result = self.classification_model.set_of_marks(
+                    input=image, masked_input=cropped_detection_file.name, classes=labels, masks=detections
                 )
-
-            result = self.classification_model.set_of_marks(
-                input=image, masked_input="temp.jpeg", classes=labels, masks=detections
-            )
 
             return detections
 
@@ -71,9 +74,10 @@ class ComposedDetectionModel(DetectionBaseModel):
             region = opened_image.crop((bbox[0], bbox[1], bbox[2], bbox[3]))
 
             # save as tempfile
-            region.save("temp.jpeg")
+            with tempfile.NamedTemporaryFile(suffix=".jpeg", dir=".", prefix="detection_") as cropped_detection_file:
+                region.save(cropped_detection_file.name)
 
-            result = self.classification_model.predict("temp.jpeg")
+                result = self.classification_model.predict(cropped_detection_file.name)
 
             if len(result.class_id) == 0:
                 continue


### PR DESCRIPTION
Fixed race condition due to parallel runs of the ComposedDetectionModel caused by hardcoded "temp.jpeg" filename for the cropped detection as a reference in the issue https://github.com/autodistill/autodistill/issues/175. This fix uses the tempfile module to create dynamic temporary jpeg files in the same directory as the current working directory, similar to the previous code.