### PR TITLE
fix a bug when using base name of image_name to access annotation during recording confidence.

### DIFF
--- a/autodistill/detection/detection_base_model.py
+++ b/autodistill/detection/detection_base_model.py
@@ -48,7 +48,7 @@ class DetectionBaseModel(BaseModel):
         Path(annotations_directory_path).mkdir(parents=True, exist_ok=True)
         for image_name in image_names:
             detections = annotations[image_name]
-            yolo_annotations_name, _ = os.path.splitext(image_name)
+            yolo_annotations_name, _ = os.path.splitext(os.path.basename(image_name))
             confidence_path = os.path.join(
                 annotations_directory_path,
                 "confidence-" + yolo_annotations_name + ".txt",
@@ -114,7 +114,8 @@ class DetectionBaseModel(BaseModel):
         )
 
         if record_confidence:
-            image_names = [os.path.basename(f_path) for f_path in image_paths]
+            #image_names = [os.path.basename(f_path) for f_path in image_paths]
+            image_names = image_paths
             self._record_confidence_in_files(
                 output_folder + "/annotations", image_names, detections_map
             )


### PR DESCRIPTION
Line 116 of autodistill/detection/detection_base_model.py file
```
if record_confidence:
            #image_names = [os.path.basename(f_path) for f_path in image_paths]
            image_names = image_paths
            self._record_confidence_in_files(
                output_folder + "/annotations", image_names, detections_map
            )
```
Here the  `image_names` should be full path instead of base name, because the keys in `annotations` and `images` in dataset are full path. 

Line 51 of autodistill/detection/detection_base_model.py file
```
 yolo_annotations_name, _ = os.path.splitext(os.path.basename(image_name))

```
Here `os.path.splittext` should work with base name instead of full path due to my previous fix. 

Original code would have bug when you try to run `line 50` of this file. The `image_name` was base name of the file instead of full path, but the keys for `annotations` are full path. 

This bug won't show up until you set `record_confidence = True` for the `label` method of  `DetectionBaseModel` class.
