### PR TITLE
Added ppm support and fixed attribute types

### DIFF
--- a/test/test_load_image.py
+++ b/test/test_load_image.py
@@ -3,6 +3,8 @@ from autodistill.helpers import load_image
 from PIL import Image
 import cv2
 import numpy as np
+import os
+import tempfile
 
 TEST_IMAGE = "test/data/dog.jpeg"
 
@@ -31,3 +33,36 @@ assert isinstance(load_image(string_image, return_format="numpy"), np.ndarray)
 assert isinstance(load_image(url, return_format="PIL"), Image.Image)
 assert isinstance(load_image(url, return_format="cv2"), np.ndarray)
 assert isinstance(load_image(url, return_format="numpy"), np.ndarray)
+
+# Test PPM support if test_ppm_support is available
+try:
+    from test_ppm_support import create_test_ppm
+    
+    # Create a test PPM file
+    TEST_PPM = create_test_ppm()
+    
+    # Test PPM loading
+    assert isinstance(load_image(TEST_PPM, return_format="PIL"), Image.Image)
+    assert isinstance(load_image(TEST_PPM, return_format="cv2"), np.ndarray)
+    assert isinstance(load_image(TEST_PPM, return_format="numpy"), np.ndarray)
+    
+    # Clean up
+    if os.path.exists(TEST_PPM):
+        os.remove(TEST_PPM)
+        
+    print("PPM support tests passed!")
+except (ImportError, ModuleNotFoundError):
+    print("Skipping PPM tests - test_ppm_support module not found")
+
+# Test error handling for non-image file
+with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as tmp:
+    tmp.write("This is not an image.")
+    tmp_path = tmp.name
+try:
+    try:
+        load_image(tmp_path)
+        assert False, "Expected ValueError for non-image file"
+    except ValueError as e:
+        assert "not a valid image" in str(e)
+finally:
+    os.remove(tmp_path)

--- a/test/test_ppm_support.py
+++ b/test/test_ppm_support.py
@@ -1,0 +1,60 @@
+import os
+import sys
+import numpy as np
+import cv2
+from PIL import Image
+
+# Add parent directory to path so we can import autodistill
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from autodistill.helpers import load_image
+
+def create_test_ppm(filepath="test/data/test.ppm"):
+    """Create a simple PPM image file for testing"""
+    # Ensure directory exists
+    os.makedirs(os.path.dirname(filepath), exist_ok=True)
+    
+    # Create a simple 100x100 colored image
+    width, height = 100, 100
+    
+    # PPM P6 format (binary)
+    with open(filepath, 'wb') as f:
+        f.write(b'P6\n')
+        f.write(f'{width} {height}\n'.encode())
+        f.write(b'255\n')  # Max color value
+        
+        # Write RGB data
+        for y in range(height):
+            for x in range(width):
+                # Create a gradient
+                r = (x * 255) // width
+                g = (y * 255) // height
+                b = ((x+y) * 255) // (width+height)
+                f.write(bytes([r, g, b]))
+    
+    return filepath
+
+def test_ppm_loading():
+    """Test that PPM files can be loaded correctly using the load_image function"""
+    # Create a test PPM file
+    test_file = create_test_ppm()
+    
+    # Test loading with various return formats
+    pil_image = load_image(test_file, return_format="PIL")
+    assert isinstance(pil_image, Image.Image), "Failed to load PPM as PIL Image"
+    
+    cv2_image = load_image(test_file, return_format="cv2")
+    assert isinstance(cv2_image, np.ndarray), "Failed to load PPM as cv2 image"
+    assert len(cv2_image.shape) == 3, "PPM should be loaded as a 3-channel image"
+    
+    numpy_image = load_image(test_file, return_format="numpy")
+    assert isinstance(numpy_image, np.ndarray), "Failed to load PPM as numpy array"
+    assert len(numpy_image.shape) == 3, "PPM should be loaded as a 3-channel image"
+    
+    print("All PPM loading tests passed!")
+    
+    # Clean up
+    os.remove(test_file)
+
+if __name__ == "__main__":
+    test_ppm_loading()


### PR DESCRIPTION
This pull request introduces support for handling PPM image files in the `autodistill` library, along with corresponding tests to ensure functionality. The changes include updates to the `load_image` function, enhancements to the `split_data` function, and new test cases to validate PPM support.

### Enhancements to PPM handling:

* [`autodistill/helpers.py`](diffhunk://#diff-a6570d85123e7de60b1f1a7d702b43f7b6c236f805287e4c0c88ff9ac24086b5R64-R85): Added special handling for PPM files in the `load_image` function, including fallback mechanisms for different formats (`PIL`, `cv2`, and `numpy`).
* [`autodistill/helpers.py`](diffhunk://#diff-a6570d85123e7de60b1f1a7d702b43f7b6c236f805287e4c0c88ff9ac24086b5L88-R110): Updated the `split_data` function to convert `.ppm` images to `.jpg` during preprocessing, ensuring consistency with other image formats. [[1]](diffhunk://#diff-a6570d85123e7de60b1f1a7d702b43f7b6c236f805287e4c0c88ff9ac24086b5L88-R110) [[2]](diffhunk://#diff-a6570d85123e7de60b1f1a7d702b43f7b6c236f805287e4c0c88ff9ac24086b5R122-R126)

### New tests for PPM support:

* [`test/test_load_image.py`](diffhunk://#diff-15f2bac90b23fc71cfae69abb1fa57103589721eb9abc286e572fa8ae8f590a8R36-R68): Added test cases to validate PPM file loading for all supported return formats (`PIL`, `cv2`, and `numpy`). Also included tests for error handling with non-image files.
* [`test/test_ppm_support.py`](diffhunk://#diff-9339d67a4c09beba8d239d333520a56f0d36266929f07eb1a8f33bf5aeab6fc9R1-R60): Introduced a utility to create test PPM files and added a standalone test script to verify PPM loading functionality.

### Minor updates for test setup:

* [`test/test_load_image.py`](diffhunk://#diff-15f2bac90b23fc71cfae69abb1fa57103589721eb9abc286e572fa8ae8f590a8R6-R7): Imported additional modules (`os` and `tempfile`) to support new test cases.