### PR TITLE
Update mkdocs.yml to include autorefs plugin and adjust pip install command in docs.yml

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,5 +13,5 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: 3.x
-      - run: pip install mkdocs==1.5.2 mkdocs-material==9.1.21 mkdocstrings==0.22.0 mkdocstrings-python==1.3.0 mkdocs-material-extensions==1.1.1 "mkdocs-material[imaging]" pillow cairosvg --upgrade
+      - run: pip install mkdocs==1.5.2 mkdocs-material==9.1.21 mkdocs-autorefs==0.5.0 mkdocstrings==0.22.0 mkdocstrings-python==1.3.0 mkdocs-material-extensions==1.1.1 "mkdocs-material[imaging]" pillow cairosvg --upgrade
       - run: mkdocs gh-deploy --force

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -152,6 +152,8 @@ theme:
 plugins:
   - mkdocstrings
   - search
+  - autorefs:
+      link_titles: true
 
 markdown_extensions:
   - admonition


### PR DESCRIPTION
This pull request updates the documentation build process by introducing the `mkdocs-autorefs` plugin and configuring it in the `mkdocs.yml` file. The changes aim to enhance cross-referencing capabilities within the documentation.

### Updates to documentation build process:

* [`.github/workflows/docs.yml`](diffhunk://#diff-9cf2000c53760d837a449f874e53f792819108d3a4bf346336d0f7d082deae2cL16-R16): Added the `mkdocs-autorefs` plugin (version 0.5.0) to the list of Python packages installed during the documentation build process.
* [`mkdocs.yml`](diffhunk://#diff-98d0f806abc9af24e6a7c545d3d77e8f9ad57643e27211d7a7b896113e420ed2R155-R156): Configured the `mkdocs-autorefs` plugin with the `link_titles: true` option to enable automatic linking of titles within the documentation.

Related issue: #194 